### PR TITLE
Show navigation link to Spanish language site

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -57,7 +57,7 @@
       English
     </a>
   </li>
-  {% elsif false %}
+  {% else %}
   {% comment %}Link to the Spanish language site{% endcomment %}
   <li>
     <a href="{{ site.alternate_url_es }}" style="font-weight: 500; {% if include.is_header_navigation %}color: var(--secondary-color);{% endif %}">


### PR DESCRIPTION
This change will show the “Español” link on the English language site.

<img width="566" alt="Screen Shot 2021-06-13 at 7 48 00 PM" src="https://user-images.githubusercontent.com/926616/121833010-4591df00-cc80-11eb-933a-43bce69840cb.png">
